### PR TITLE
Fix failing build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.13.3
+FROM elixir:1.15.4-otp-25-alpine
 
 RUN apt-get update -y \
     && apt-get -y install apt-transport-https curl lsb-release unzip ca-certificates gnupg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.15.4-otp-25-alpine
+FROM elixir:1.15.4-otp-25
 
 RUN apt-get update -y \
     && apt-get -y install apt-transport-https curl lsb-release unzip ca-certificates gnupg

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,17 +37,13 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
     && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
     "/opt/google/chrome/google-chrome"
 
-# Install php7
-RUN apt-get -y install apt-transport-https lsb-release ca-certificates \
-    && wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
+# Prerequisites for php7
+RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
     && sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list' \
-    && apt-get update \
-    && apt-get install php7.2 -y
-
 
 # Installs
 RUN apt-get update -y \
-    && apt-get install -y nodejs=18.15.0-1nodesource1 yarn google-cloud-sdk docker-ce \
+    && apt-get install -y php7.2 nodejs=18.15.0-1nodesource1 yarn google-cloud-sdk docker-ce \
     && apt reinstall fonts-noto-color-emoji
 
 # Install docker-compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM elixir:1.13.3
 
 RUN apt-get update -y \
-    && apt-get -y install apt-transport-https curl lsb-release unzip
+    && apt-get -y install apt-transport-https curl lsb-release unzip ca-certificates gnupg
 
 # Prerequisites for `google-cloud-platform` - https://cloud.google.com/sdk/downloads#apt-get
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
@@ -13,7 +13,9 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
     && echo "deb https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee -a /etc/apt/sources.list.d/docker.list
 
 # Prerequisites for `node`
-RUN curl -sL https://deb.nodesource.com/setup_18.15 | bash -
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 
 # Prerequisites for `yarn` - https://yarnpkg.com/lang/en/docs/install/#linux-tab
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
@@ -45,7 +47,7 @@ RUN apt-get -y install apt-transport-https lsb-release ca-certificates \
 
 # Installs
 RUN apt-get update -y \
-    && apt-get install -y nodejs yarn google-cloud-sdk docker-ce \
+    && apt-get install -y nodejs=18.15.0-1nodesource1 yarn google-cloud-sdk docker-ce \
     && apt reinstall fonts-noto-color-emoji
 
 # Install docker-compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM elixir:1.13.3
 
-RUN apt-get update -y \ 
-    && apt-get -y install apt-transport-https curl lsb-release unzip 
+RUN apt-get update -y \
+    && apt-get -y install apt-transport-https curl lsb-release unzip
 
 # Prerequisites for `google-cloud-platform` - https://cloud.google.com/sdk/downloads#apt-get
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
-    && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list  \ 
-    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - 
+    && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list  \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
 # Prerequisites for `docker`
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-    && echo "deb https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee -a /etc/apt/sources.list.d/docker.list 
+    && echo "deb https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee -a /etc/apt/sources.list.d/docker.list
 
 # Prerequisites for `node`
 RUN curl -sL https://deb.nodesource.com/setup_18.15 | bash -
@@ -26,14 +26,14 @@ RUN FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases
     && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.bz2 $FIREFOX_URL \
     && echo "$FIREFOX_SHA256 /tmp/firefox.tar.bz2" | sha256sum -c \
     && tar -jxf /tmp/firefox.tar.bz2 \
-    && rm /tmp/firefox.tar.bz2 
+    && rm /tmp/firefox.tar.bz2
 
 # install chrome
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     && (dpkg -i /tmp/google-chrome-stable_current_amd64.deb || apt-get -fy install)  \
     && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
     && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
-    "/opt/google/chrome/google-chrome" 
+    "/opt/google/chrome/google-chrome"
 
 # Install php7
 RUN apt-get -y install apt-transport-https lsb-release ca-certificates \


### PR DESCRIPTION
These changes aim to achieve the following:
- Fix the docker image not building due to changes to nodesource's repository
- Change the elixir image from `elixir:1.13.3` to `elixir:1.15.4-otp-25-alpine` to closely match what the backend image uses.