### PR TITLE
(Chore): Improve build image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN apt-get update -y \
     && apt reinstall fonts-noto-color-emoji
 
 # Edit /etc/hosts
-RUN echo -e "127.0.0.1 localtest.me\n::1 localtest.me" > /etc/hosts
+RUN echo -e "127.0.0.1 localtest.me\n::1 localtest.me" >> /etc/hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,6 @@ RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 RUN apt-get update -y \
     && apt-get install -y php8.2 nodejs=18.15.0-1nodesource1 yarn \
     && apt reinstall fonts-noto-color-emoji
+
+# Edit /etc/hosts
+RUN echo -e "127.0.0.1 localtest.me\n::1 localtest.me" > /etc/hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 
 # Installs
 RUN apt-get update -y \
-    && apt-get install -y php8.2 nodejs=18.15.0-1nodesource1 yarn \
+    && apt-get install -y php8.2 nodejs=18.15.0-1nodesource1 yarn git \
     && apt reinstall fonts-noto-color-emoji

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,3 @@ RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 RUN apt-get update -y \
     && apt-get install -y php8.2 nodejs=18.15.0-1nodesource1 yarn \
     && apt reinstall fonts-noto-color-emoji
-
-# Edit /etc/hosts
-RUN echo -e "127.0.0.1 localtest.me\n::1 localtest.me" >> /etc/hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,7 @@
-FROM elixir:1.15.4-otp-25
+FROM elixir:1.15.4-otp-25-slim
 
 RUN apt-get update -y \
     && apt-get -y install apt-transport-https curl lsb-release unzip ca-certificates gnupg
-
-# Prerequisites for `google-cloud-platform` - https://cloud.google.com/sdk/downloads#apt-get
-RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
-    && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list  \
-    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-
-# Prerequisites for `docker`
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-    && echo "deb https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee -a /etc/apt/sources.list.d/docker.list
 
 # Prerequisites for `node`
 RUN mkdir -p /etc/apt/keyrings \
@@ -21,15 +12,6 @@ RUN mkdir -p /etc/apt/keyrings \
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-# install firefox
-ENV PATH /firefox:$PATH
-RUN FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/85.0.2/linux-x86_64/en-US/firefox-85.0.2.tar.bz2" \
-    FIREFOX_SHA256="98763f4b1526811967d71e1bbb9552a9a3fd877321ecb497083b9e313b528c31" \
-    && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.tar.bz2 $FIREFOX_URL \
-    && echo "$FIREFOX_SHA256 /tmp/firefox.tar.bz2" | sha256sum -c \
-    && tar -jxf /tmp/firefox.tar.bz2 \
-    && rm /tmp/firefox.tar.bz2
-
 # install chrome
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     && (dpkg -i /tmp/google-chrome-stable_current_amd64.deb || apt-get -fy install)  \
@@ -37,15 +19,11 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
     && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
     "/opt/google/chrome/google-chrome"
 
-# Prerequisites for php7
+# Prerequisites for php8
 RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg \
     && sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 
 # Installs
 RUN apt-get update -y \
-    && apt-get install -y php7.2 nodejs=18.15.0-1nodesource1 yarn google-cloud-sdk docker-ce \
+    && apt-get install -y php8.2 nodejs=18.15.0-1nodesource1 yarn \
     && apt reinstall fonts-noto-color-emoji
-
-# Install docker-compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.28.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose \
-    && chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
These changes aim at reducing the image size as well as ensure the package versions are closer to what is on live.

This image is currently only used to test e2e tests. For that purpose currently, google-cloud-platform, docker and firefox are not needed.